### PR TITLE
fix(ruby): specific ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+ruby "~> 2.7"
 gem 'rake'
 
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,5 +58,8 @@ DEPENDENCIES
   rake
   simplecov
 
+RUBY VERSION
+   ruby 2.7.4p191
+
 BUNDLED WITH
    2.2.28


### PR DESCRIPTION
Upgrade Heroku stack, we have to specific the ruby version in `Gemfile`
- https://www.sejuku.net/plus/question/detail/5584
- https://devcenter.heroku.com/ja/articles/getting-started-with-rails5#specify-your-ruby-version
- https://devcenter.heroku.com/articles/ruby-versions#selecting-a-version-of-ruby